### PR TITLE
undefined $norig fix in lib/diff3.php

### DIFF
--- a/lib/diff3.php
+++ b/lib/diff3.php
@@ -155,6 +155,8 @@ class Diff3 {
                         $orig = array_splice($e1->orig, 0, $norig);
                         array_splice($e2->orig, 0, $norig);
                         $bb->input($orig);
+                    }else{
+                    	$norig = 0;
                     }
                     
                     if ($e1->type == 'copy')


### PR DESCRIPTION
having an add and copy block causes the $norig value to assume the last value. This causes the copy block to be corrupted, data is substracted from the final block, but not from the orig block.

This case is fixed by setting norig to false.
