### PR TITLE
인터위키 테이블 업데이트

### DIFF
--- a/data/intermap.txt
+++ b/data/intermap.txt
@@ -5,7 +5,7 @@ MeatBall http://www.usemod.com/cgi-bin/mb.pl?
 MoinMoin https://moinmo.in/
 UseMod http://www.usemod.com/cgi-bin/wiki.pl?
 TWiki http://twiki.org/cgi-bin/view/
-WikiPedia http://en.wikipedia.org/wiki/
+WikiPedia https://en.wikipedia.org/wiki/
 ZWiki http://www.zwiki.org/
 FoxWiki http://fox.wikis.com/wc.dll?Wiki~
 AndStuff http://andstuff.org/wiki.php?
@@ -14,7 +14,6 @@ Unreal http://wiki.beyondunreal.com/wiki/
 # MetaWikis
 Google http://www.google.com/search?q=
 GoogleGroups http://groups.google.com/groups?q=
-KnowHow http://www2.iro.umontreal.ca/~paquetse/cgi-bin/wiki.cgi?
 Bzla http://bugzilla.gnome.org/show_bug.cgi?id=
 BugZilla http://bugzilla.gnome.org/show_bug.cgi?id=
 Foldoc http://www.foldoc.org/foldoc/foldoc.cgi?


### PR DESCRIPTION
 - 삭제된 줄은 죽은 링크로써 유지할 이유가 없다고 생각합니다.
 - 위키미디어/위키백과는 https 로만 서비스되므로 (중국 등 예외) 굳이 http 들렀다가 https로 갈 것 없이 https로 연결하게 합니다.