### PR TITLE
Update asciimathml

### DIFF
--- a/config.php.default
+++ b/config.php.default
@@ -57,6 +57,7 @@ $inline_latex=0; # 0/1(on/off), mimetex, itex, etc.
 #$latex_convert_options='-crop 0x0 -density 120x120'; # change convert options for the latex processor
 #$latex_renumbering=1; # renumbering tex equations
 #$latex_allinone=1; # experimental feature. make a temporary latex file into all in one text.
+#$use_default_mathml_style=1; # use default mathml style
 $lang='auto'; # check language automatically.
 #$default_lang='ko'; # default language
 $charset='utf-8'; # default character set. euc-kr etc.
@@ -180,8 +181,6 @@ $javascripts=array(
 	#'defer,mobile.js',
 	#'defer,folding.js',
 	#'defer,googlehi.js',
-	'ASCIIMathML.js',
-	#'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML', # for ASCIIMathML.js + MathJax
 );
 
 #$diffonly=1; # show only diff infos (do not show wiki contents)

--- a/config.php.default.ko
+++ b/config.php.default.ko
@@ -57,6 +57,7 @@ $inline_latex=0; # 인라인 latex 사용 (기본값)
 #$latex_convert_options='-crop 0x0 -density 120x120'; # change convert options for the latex processor
 #$latex_renumbering=1; # tex 수식 번호 재지정
 #$latex_allinone=1; # experimental. 텍을 하나의 파일로 만들어 한번에 랜더링함
+#$use_default_mathml_style=1; # mathml 기본 글꼴 스타일 사용
 $lang='auto'; # 기본 언어 (자동) 혹은 ko, ko_KR, en, en_US 등등
 #$default_lang='ko'; # default language
 $charset='utf-8'; # 기본 문자셋. euc-kr etc.
@@ -180,8 +181,6 @@ $javascripts=array(
 	#'defer,mobile.js',
 	#'defer,folding.js',
 	#'defer,googlehi.js',
-	'ASCIIMathML.js',
-	#'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML', # for ASCIIMathML.js + MathJax
 );
 
 #$diffonly=1; # show only diff infos (do not show wiki contents)

--- a/local/ASCIIMathML.js
+++ b/local/ASCIIMathML.js
@@ -25,6 +25,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 General Public License (at http://www.gnu.org/copyleft/gpl.html) 
 for more details.
 */
+var asciimath = {};
+
 var checkForMathML = true;   // check if browser can display MathML
 var notifyIfNoMathML = true; // display note if no MathML capability
 var alertIfNoMathML = false;  // show alert box if no MathML capability
@@ -923,3 +925,10 @@ else
 }
 
 */
+//expose some functions to outside
+asciimath.newcommand = newcommand;
+//asciimath.newsymbol = newsymbol;
+asciimath.AMprocessNode = AMprocessNode;
+asciimath.processNodeR = AMprocessNodeR;
+asciimath.parseMath = AMparseMath;
+asciimath.translate = translate;

--- a/plugin/Info.php
+++ b/plugin/Info.php
@@ -172,7 +172,7 @@ function _parse_rlog($formatter,$log,$options=array()) {
            $tmp = explode(',', $ip);
            $lastip = $ip = array_pop($tmp);
          }
-         $user=trim($dummy[1]);
+         $user = !empty($dummy[1]) ? trim($dummy[1]) : 'Anonymous';
          if (($p = strpos($user,' ')) !== false) { // XXX
            $user = substr($user, 0, $p);
          } else if (substr($user, 0, 9) == 'Anonymous') {

--- a/plugin/processor/asciimathml.php
+++ b/plugin/processor/asciimathml.php
@@ -1,31 +1,20 @@
 <?php
-// Copyright 2005-2010 Won-Kyu Park <wkpark at kldp.org>
+// Copyright 2005-2022 Won-Kyu Park <wkpark at kldp.org>
 // All rights reserved. Distributable under GPL see COPYING
 // a asciimathml processor plugin by AnonymousDoner
 //
 // Author: Won-Kyu Park <wkpark@kldp.org> and AnonymousDoner
-// Date: 2007-11-02
+// Since: 2007-11-02
+// LastModified: 2022-10-29
 // Name: a AsciiMathML processor
 // Description: It support AsciiMathML
 // URL: MoniWiki:AsciiMathML
-// Version: $Revision: 1.11 $
+// Version: $Revision: 1.12 $
 // License: GPL
 //
-// please see http://kldp.net/forum/message.php?msg_id=9419
-//
-// download the following javascript in the local/ dir to enable this processor:
-//  http://www1.chapman.edu/~jipsen/mathml/ASCIIMathML.js
-//  and add small code or set $_add_func=1;
-//-----x8-----
-// function translateById(objId) {
-//   AMbody = document.getElementById(objId);
-//   AMprocessNode(AMbody, false);
-//   if (isIE) { //needed to match size and font of formula to surrounding text
-//     var frag = document.getElementsByTagName('math');
-//     for (var i=0;i<frag.length;i++) frag[i].update()
-//   }
-// }
-//   AMinitSymbols();
+// Firefox and Safari support mathML but Chrome does not.
+// to use AsciiMathML with Chrome add the following javascript:
+// https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 //-----x8-----
 // to changes this processor as a default inline latex formatter:
 // 1. set $inline_latex='asciimathml';

--- a/plugin/processor/asciimathml.php
+++ b/plugin/processor/asciimathml.php
@@ -37,6 +37,8 @@ function processor_asciimathml($formatter,$value="") {
   $edit_mathbgcolor='yellow';
   $myfontfamily='Palatino Linotype'; # or serif
   $myfontcolor='#2171B1'; # red(default), black etc.
+  $myfontfamily=''; # reset font family
+  $myfontcolor=''; # reset font color
 
   #
   $flag = 0;
@@ -49,7 +51,11 @@ function processor_asciimathml($formatter,$value="") {
 
     # wikimarkup specific settings
     $bgcolor = '';
-    $fontcolor="mathcolor='$myfontcolor';\n";
+    if (isset($DBInfo->mathml_fontcolor)) {
+      $fontcolor = "mathcolor='$DBInfo->mathml_fontcolor';\n";
+    } else {
+      $fontcolor = "mathcolor='$myfontcolor';\n";
+    }
   } else {
     $flag = 1;
     $id=md5($value.'.'.microtime());
@@ -57,10 +63,19 @@ function processor_asciimathml($formatter,$value="") {
     # normal settings
     $bgcolor="mathbgcolor='$edit_mathbgcolor';\n";
   }
-  $fontfamily="mathfontfamily='$myfontfamily';\n";
+  if (isset($DBInfo->mathml_fontfamily)) {
+    $fontfamily = "mathfontfamily='$DBInfo->mathml_fontfamily';\n";
+  } else {
+    $fontfamily="mathfontfamily='$myfontfamily';\n";
+  }
+
+  $mathmlstyle = '';
+  if (empty($DBInfo->use_default_mathml_style))
+    $mathmlstyle = "$bgcolor$fontfamily$fontcolor";
 
   if ( $flag ) {
     $formatter->register_javascripts('ASCIIMathML.js');
+    $formatter->register_javascripts('//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML');
 
     if ($_add_func)
       $js=<<<AJS
@@ -87,8 +102,7 @@ function translateById(objId,flag) {
     asciimath.AMprocessNode(AMbody, false, false);
   }
 }
-
-$bgcolor$fontfamily$fontcolor
+$mathmlstyle
 if (window.MathJax) { mathfontfamily = ''; mathcolor = ''; }
 // AMinitSymbols();
 /*]]>*/

--- a/plugin/processor/asciimathml.php
+++ b/plugin/processor/asciimathml.php
@@ -71,16 +71,17 @@ function processor_asciimathml($formatter,$value="") {
   $fontfamily="mathfontfamily='$myfontfamily';\n";
 
   if ( $flag ) {
-    if ($formatter->register_javascripts('ASCIIMathML.js'));
+    $formatter->register_javascripts('ASCIIMathML.js');
 
     if ($_add_func)
       $js=<<<AJS
 <script type="text/javascript">
 /*<![CDATA[*/
 function translateById(objId,flag) {
+  var isIE = (navigator.appName.slice(0,9)=="Microsoft");
   var AMbody = document.getElementById(objId);
   // for WikiWyg mode switching
-  if (typeof math2ascii != "undefined") math2ascii(AMbody);
+
   if (isIE) { // for WikiWyg in the iframe
     var nd = AMisMathMLavailable();
     AMnoMathML = nd != null;
@@ -88,12 +89,13 @@ function translateById(objId,flag) {
     if (AMnoMathML) {
       AMbody.insertBefore(nd,AMbody.childNodes[0]);
     } else {
-      AMbody.innerHTML=AMparseMath(AMbody.innerHTML.replace(/\\$/g,'')).innerHTML;
+      AMbody.innerHTML=asciimath.parseMath(AMbody.innerHTML.replace(/\\$/g,''), true).innerHTML;
       //needed to match size and font of formula to surrounding text
       AMbody.getElementsByTagName('math')[0].update();
     }
   } else {
-    AMprocessNode(AMbody, false);
+    //asciimath.processNodeR(AMbody, false, false);
+    asciimath.AMprocessNode(AMbody, false, false);
   }
 }
 
@@ -103,7 +105,7 @@ if (window.MathJax) { mathfontfamily = ''; mathcolor = ''; }
 /*]]>*/
 </script>
 AJS;
-    if ($js) $formatter->register_javascripts($js);
+    $formatter->register_javascripts($js);
   }
 
   $out = "<span><span class=\"AM\" id=\"AM-$id\">$value</span>" .

--- a/plugin/processor/mathjax.php
+++ b/plugin/processor/mathjax.php
@@ -1,0 +1,56 @@
+<?php
+// Copyright 2022 Won-Kyu Park <wkpark at kldp.org>
+// All rights reserved. Distributable under GPL see COPYING
+// a mathjax processor plugin
+//
+// Author: Won-Kyu Park <wkpark@kldp.org>
+// Date: 2022-10-29
+// Name: a MathJAX processor
+// Description: support MathJAX
+// URL: MoniWiki:MathJaxProcessor
+// Version: $Revision: 1.0 $
+// License: GPL
+//
+// to changes this processor as a default inline latex formatter:
+// 1. set $inline_latex='mathjax';
+// 2. replace the latex processor: $processors=array('latex'=>'mathjax');
+//
+
+function processor_mathjax($formatter, $value = '') {
+    global $DBInfo;
+
+    if ($value[0] == '#' and $value[1] == '!')
+        list($line, $value) = explode("\n", $value, 2);
+
+    if (!empty($line) and strpos($line, ' ') !== FALSE)
+        list($tag, $args) = explode(' ', $line, 2);
+
+    $flag = 0;
+    if (empty($formatter->wikimarkup)) {
+        // use a md5 tag with a wikimarkup action
+        $cid = &$GLOBALS['_transient']['mathjax'];
+        if (!$cid) { $flag = 1; $cid = 1; }
+        $id = $cid;
+        $cid++;
+    } else {
+        $flag = 1;
+    }
+
+    if ($flag) {
+        $mathjax = <<<CONF
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+  tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}
+});
+</script>
+CONF;
+        $formatter->register_javascripts('//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_CHTML');
+        $formatter->register_javascripts($mathjax);
+    }
+
+    $out = "<span><span class=\"AM\" id=\"AM-$id\">$value</span>" .
+        "</span>";
+    return $out;
+}
+
+// vim:et:sts=4:sw=4

--- a/wiki.php
+++ b/wiki.php
@@ -6806,11 +6806,11 @@ function _session_start($session_id = null, $id = null) {
         if (count($tmp) >= 3)
             $domain = $_SERVER['SERVER_NAME'];
     }
-    if (empty($domain)) {
-        if (!empty($_SERVER['HTTP_HOST']) && ($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
+    if (empty($domain) && !empty($_SERVER['HTTP_HOST'])) {
+        if (($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
             $domain = substr($_SERVER['HTTP_HOST'], 0, $pos);
         } else {
-            $domain = 'localhost';
+            $domain = $_SERVER['HTTP_HOST'];
         }
     }
 

--- a/wikilib.php
+++ b/wikilib.php
@@ -1972,11 +1972,12 @@ class WikiUser {
         if (count($tmp) >= 3)
           $domain = '; Domain='.$_SERVER['SERVER_NAME'];
      }
-     if (empty($domain)) {
-        if (!empty($_SERVER['HTTP_HOST']) && ($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
+
+     if (empty($domain) && !empty($_SERVER['HTTP_HOST'])) {
+        if (($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
             $domain = substr($_SERVER['HTTP_HOST'], 0, $pos);
         } else {
-            $domain = 'localhost';
+            $domain = $_SERVER['HTTP_HOST'];
         }
         $domain = '; Domain='.$domain;
      }
@@ -2003,11 +2004,11 @@ class WikiUser {
         if (count($tmp) >= 3)
           $domain = '; Domain='.$_SERVER['SERVER_NAME'];
      }
-     if (empty($domain)) {
-        if (!empty($_SERVER['HTTP_HOST']) && ($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
+     if (empty($domain) && !empty($_SERVER['HTTP_HOST'])) {
+        if (($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false) {
             $domain = substr($_SERVER['HTTP_HOST'], 0, $pos);
         } else {
-            $domain = 'localhost';
+            $domain = $_SERVER['HTTP_HOST'];
         }
         $domain = '; Domain='.$domain;
      }


### PR DESCRIPTION
`ASCIIMathML.js`를 최근 환경에 맞게 수정합니다. (최신 버전 일부 기능 반영)
 * 최신 `ASCIIMathML.js` 사용에 문제가 있어서 기존 버전을 고수하고 몇가지 업데이트
   * 최신의 경우 `$` latex 문법이 제외됨.
   * 최신의 경우 `(function() {...})()`으로 감싸지면서 font/color등등 조정이 불가해짐
 * 이에 맞춰 `ASCIIMathML` 프로세서를 업뎃
 * `MathJaX`자체적으로 `ASCIIMathML`까지 지원하게 되고, `MathJaX`가 강력해져, MathJAX 프로세서도 별도로 추가합니다.