### PR TITLE
fixed deprecation warnings

### DIFF
--- a/lib/JSON.php
+++ b/lib/JSON.php
@@ -261,7 +261,7 @@ class Services_JSON
                 */
                 for ($c = 0; $c < $strlen_var; ++$c) {
 
-                    $ord_var_c = ord($var{$c});
+                    $ord_var_c = ord($var[$c]);
 
                     switch (true) {
                         case $ord_var_c == 0x08:
@@ -284,18 +284,18 @@ class Services_JSON
                         case $ord_var_c == 0x2F:
                         case $ord_var_c == 0x5C:
                             // double quote, slash, slosh
-                            $ascii .= '\\'.$var{$c};
+                            $ascii .= '\\'.$var[$c];
                             break;
 
                         case (($ord_var_c >= 0x20) && ($ord_var_c <= 0x7F)):
                             // characters U-00000000 - U-0000007F (same as ASCII)
-                            $ascii .= $var{$c};
+                            $ascii .= $var[$c];
                             break;
 
                         case (($ord_var_c & 0xE0) == 0xC0):
                             // characters U-00000080 - U-000007FF, mask 110XXXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                            $char = pack('C*', $ord_var_c, ord($var{$c + 1}));
+                            $char = pack('C*', $ord_var_c, ord($var[$c + 1]));
                             $c += 1;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -305,8 +305,8 @@ class Services_JSON
                             // characters U-00000800 - U-0000FFFF, mask 1110XXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]));
                             $c += 2;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -316,9 +316,9 @@ class Services_JSON
                             // characters U-00010000 - U-001FFFFF, mask 11110XXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]));
                             $c += 3;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -328,10 +328,10 @@ class Services_JSON
                             // characters U-00200000 - U-03FFFFFF, mask 111110XX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}),
-                                         ord($var{$c + 4}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]),
+                                         ord($var[$c + 4]));
                             $c += 4;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -341,11 +341,11 @@ class Services_JSON
                             // characters U-04000000 - U-7FFFFFFF, mask 1111110X
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                         ord($var{$c + 1}),
-                                         ord($var{$c + 2}),
-                                         ord($var{$c + 3}),
-                                         ord($var{$c + 4}),
-                                         ord($var{$c + 5}));
+                                         ord($var[$c + 1]),
+                                         ord($var[$c + 2]),
+                                         ord($var[$c + 3]),
+                                         ord($var[$c + 4]),
+                                         ord($var[$c + 5]));
                             $c += 5;
                             $utf16 = $this->utf82utf16($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -520,7 +520,7 @@ class Services_JSON
                     for ($c = 0; $c < $strlen_chrs; ++$c) {
 
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
-                        $ord_chrs_c = ord($chrs{$c});
+                        $ord_chrs_c = ord($chrs[$c]);
 
                         switch (true) {
                             case $substr_chrs_c_2 == '\b':
@@ -550,7 +550,7 @@ class Services_JSON
                             case $substr_chrs_c_2 == '\\/':
                                 if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
                                    ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
-                                    $utf8 .= $chrs{++$c};
+                                    $utf8 .= $chrs[++$c];
                                 }
                                 break;
 
@@ -563,7 +563,7 @@ class Services_JSON
                                 break;
 
                             case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                                $utf8 .= $chrs{$c};
+                                $utf8 .= $chrs[$c];
                                 break;
 
                             case ($ord_chrs_c & 0xE0) == 0xC0:
@@ -610,7 +610,7 @@ class Services_JSON
                 } elseif (preg_match('/^\[.*\]$/s', $str) || preg_match('/^\{.*\}$/s', $str)) {
                     // array, or object notation
 
-                    if ($str{0} == '[') {
+                    if ($str[0] == '[') {
                         $stk = array(SERVICES_JSON_IN_ARR);
                         $arr = array();
                     } else {
@@ -649,7 +649,7 @@ class Services_JSON
                         $top = end($stk);
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
 
-                        if (($c == $strlen_chrs) || (($chrs{$c} == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
+                        if (($c == $strlen_chrs) || (($chrs[$c] == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
                             // found a comma that is not inside a string, array, etc.,
                             // OR we've reached the end of the character list
                             $slice = substr($chrs, $top['where'], ($c - $top['where']));
@@ -691,12 +691,12 @@ class Services_JSON
 
                             }
 
-                        } elseif ((($chrs{$c} == '"') || ($chrs{$c} == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
+                        } elseif ((($chrs[$c] == '"') || ($chrs[$c] == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
                             // found a quote, and we are not inside a string
-                            array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs{$c}));
+                            array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs[$c]));
                             //print("Found start of string at {$c}\n");
 
-                        } elseif (($chrs{$c} == $top['delim']) &&
+                        } elseif (($chrs[$c] == $top['delim']) &&
                                  ($top['what'] == SERVICES_JSON_IN_STR) &&
                                  ((strlen(substr($chrs, 0, $c)) - strlen(rtrim(substr($chrs, 0, $c), '\\'))) % 2 != 1)) {
                             // found a quote, we're in a string, and it's not escaped
@@ -705,24 +705,24 @@ class Services_JSON
                             array_pop($stk);
                             //print("Found end of string at {$c}: ".substr($chrs, $top['where'], (1 + 1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '[') &&
+                        } elseif (($chrs[$c] == '[') &&
                                  in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                             // found a left-bracket, and we are in an array, object, or slice
                             array_push($stk, array('what' => SERVICES_JSON_IN_ARR, 'where' => $c, 'delim' => false));
                             //print("Found start of array at {$c}\n");
 
-                        } elseif (($chrs{$c} == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
+                        } elseif (($chrs[$c] == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
                             // found a right-bracket, and we're in an array
                             array_pop($stk);
                             //print("Found end of array at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '{') &&
+                        } elseif (($chrs[$c] == '{') &&
                                  in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                             // found a left-brace, and we are in an array, object, or slice
                             array_push($stk, array('what' => SERVICES_JSON_IN_OBJ, 'where' => $c, 'delim' => false));
                             //print("Found start of object at {$c}\n");
 
-                        } elseif (($chrs{$c} == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
+                        } elseif (($chrs[$c] == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
                             // found a right-brace, and we're in an object
                             array_pop($stk);
                             //print("Found end of object at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");

--- a/lib/confutils.php
+++ b/lib/confutils.php
@@ -184,7 +184,7 @@ class Config_base {
 
             if (!$key) {
                 // first line
-                if ($line{0} == '<' and $line{1} == '?') {
+                if ($line[0] == '<' and $line[1] == '?') {
                     $date = date('Y-m-d h:i:s');
                     $nlines[] = '<'.'?php'."\n";
                     $nlines[] = <<<HEADER

--- a/lib/dict.text.php
+++ b/lib/dict.text.php
@@ -138,7 +138,7 @@ function _file_match($fp,$key,$lower,$upper,$fsize,$klen=1,$match_prefix=true,$e
         $l = fgets($fp,1024);
         $seek +=strlen($l);
 
-        if ($l{0} == '#') continue;
+        if ($l[0] == '#') continue;
         $mykey= strtok($l,' \t\n,:');
         #print '==>'.$l;
         #$llen = mb_strlen($mykey,$encoding);

--- a/lib/openid.php
+++ b/lib/openid.php
@@ -220,7 +220,7 @@ class SimpleOpenID{
 		$response = call_user_func(array(&$this,$this->_request),$this->openid_url_identity);
 		$new_url=$this->getHTTPEquiv($response);
 		if ($new_url) {
-			if ($new_url{0}=='/') $new_url=$this->openid_url_identity.$new_url;
+			if ($new_url[0]=='/') $new_url=$this->openid_url_identity.$new_url;
 			$response = call_user_func(array(&$this,$this->_request),$new_url);
 		}
 		list($servers, $delegates) = $this->HTML2OpenIDServer($response);

--- a/lib/stemmer.ko.php
+++ b/lib/stemmer.ko.php
@@ -305,7 +305,7 @@ class KoreanStemmer {
             $pre = implode('-',$words);
 
             if (!empty($nword)) {
-                if ($type{0} == 'n') { // noun
+                if ($type[0] == 'n') { // noun
                     $stem = $this->getNoun($nword, $match);
                     #print '*** stem'.$nword.'=='.$stem."\n";
                     if (!empty($stem))
@@ -329,13 +329,13 @@ class KoreanStemmer {
         list($r, $cand, $last) = $this->isWord($word);
 
         // return first candidate XXX
-        if (isset($cand[0]) and $cand[0][1]{0} == 'n') return $cand[0][0];
+        if (isset($cand[0]) and $cand[0][1][0] == 'n') return $cand[0][0];
         else $stem=$this->getNoun($word,$match);
 
         if ($stem) {
             list ($r1, $cand1,$last1) = $this->isWord($stem);
             $type=$cand1[0][1];
-            if ($cand1[0][1]{0} == 'n') return $stem;
+            if ($cand1[0][1][0] == 'n') return $stem;
         }
         #if ($stem and $this->isWord($stem) == 'n') return $stem;
         $verb=$this->getVerb($word,$vmatch);
@@ -364,7 +364,7 @@ class KoreanStemmer {
             $pword=substr($word,0,-strlen($match[1]));
             if ($pword) {
                 list ($r, $cand,$last) = $this->isWord($pword);
-                if ($cand[0][1]{0} == 'n') return $pword;
+                if ($cand[0][1][0] == 'n') return $pword;
             }
             $pword=$this->getWordRule($pword).$match[1];
             preg_match('/('.$this->_josa_rule.')$/S',$pword,$nmatch);

--- a/lib/stemmer.php
+++ b/lib/stemmer.php
@@ -383,7 +383,7 @@ class PorterStemmer
     {
         $c = self::$regex_consonant;
 
-        return preg_match("#$c{2}$#", $str, $matches) AND $matches[0]{0} == $matches[0]{1};
+        return preg_match("#$c[2]$#", $str, $matches) AND $matches[0][0] == $matches[0][1];
     }
 
 
@@ -400,9 +400,9 @@ class PorterStemmer
 
         return     preg_match("#($c$v$c)$#", $str, $matches)
                AND strlen($matches[1]) == 3
-               AND $matches[1]{2} != 'w'
-               AND $matches[1]{2} != 'x'
-               AND $matches[1]{2} != 'y';
+               AND $matches[1][2] != 'w'
+               AND $matches[1][2] != 'x'
+               AND $matches[1][2] != 'y';
     }
 }
 ?>

--- a/monisetup.php
+++ b/monisetup.php
@@ -1,9 +1,15 @@
 <?php
 // Copyright 2003-2007 Won-Kyu Park <wkpark at kldp.org> all rights reserved.
 // distributable under GPL see COPYING 
-// $Id$
+
+// PHP_VERSION_ID is available as of PHP 5.2.7
+if (!defined('PHP_VERSION_ID')) {
+  $version = explode('.', PHP_VERSION);
+  define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+}
 
 function _stripslashes($str) {
+  if (PHP_VERSION_ID >= 50400) return $str;
   return get_magic_quotes_gpc() ? stripslashes($str):$str;
 }
 

--- a/plugin/Diff.php
+++ b/plugin/Diff.php
@@ -23,7 +23,7 @@ function code_diff($diff, $options = array()) {
   $i = 0;
   while($i < $sz) {
     for (; $i < $sz; $i++) {
-      if ($lines[$i]{0} == '@') {
+      if ($lines[$i][0] == '@') {
         break;
       } else if (preg_match('/^-{3} ([^ \t]+)/',$lines[$i], $m)
         and preg_match('/^\+{3} /',$lines[$i+1])) {
@@ -46,7 +46,7 @@ function code_diff($diff, $options = array()) {
     $next_patch = 0;
     for (;$i < $sz; $i++) {
       $line = $lines[$i];
-      $marker = $line{0};
+      $marker = $line[0];
       if (in_array($marker, array('-','+','@',' '))) $line = substr($line, 1);
       else {
         if (empty($new) and empty($orig)) break;

--- a/plugin/Keywords.php
+++ b/plugin/Keywords.php
@@ -193,7 +193,7 @@ EOF;
             $lines=explode("\n",($p->get_raw_body()));
             $lines=array_merge($lines,$lines0);
             foreach ($lines as $line) {
-                if (isset($line{0}) and $line{0}=='#') continue;
+                if (isset($line[0]) and $line[0]=='#') continue;
                 $common.="\n".$line;
             }
             $common=rtrim($common);

--- a/plugin/MathChooser.php
+++ b/plugin/MathChooser.php
@@ -76,7 +76,7 @@ JS;
         foreach ($lines as $l) {
             $l=rtrim($l);
             if (empty($l)) continue;
-            if ($l{0}=='#') continue;
+            if ($l[0]=='#') continue;
             if (substr($l,-1)=='&') { $o.=$l; continue; }
             else if (!empty($o)) { $l=$o.$l; $o='';}
             list ($k,$v)=explode(' ',$l,2);

--- a/plugin/Rating.php
+++ b/plugin/Rating.php
@@ -186,7 +186,7 @@ function do_rating($formatter,$options) {
                     $head='';
                     while (true) {
                         list($line,$body)=explode("\n",$body,2);
-                        if ($line{0}=='#') $head.=$line."\n";
+                        if ($line[0]=='#') $head.=$line."\n";
                         else {
                             $body=$line."\n".$body;
                             break;

--- a/plugin/TTFText.php
+++ b/plugin/TTFText.php
@@ -35,7 +35,7 @@ function macro_TTFText($formatter,$value,$params=array()) {
         list($k,$v)=explode('=',trim($arg),2);
         if ($k == 'font') {
             $font=$v;
-            if ($font{0}!='/') {
+            if ($font[0]!='/') {
                 $real=getcwd().'/data/'.$font; # XXX
                 if (!preg_match('/\.ttf$/i',$real))
                     $real.='.ttf';

--- a/plugin/admin.php
+++ b/plugin/admin.php
@@ -96,7 +96,7 @@ function macro_admin($formatter,$value='',$options=array()) {
         if (!$handle) continue;
         while ($file= readdir($handle)) {
             if (is_dir($dir.'/'.$pdir.'/'.$file)) continue;
-            if ($file{0}=='.') continue;
+            if ($file[0]=='.') continue;
             if (substr($file,-4)!='.php') continue;
             $name= substr($file,0,-4);
             $plugins[strtolower($name)]= $name;

--- a/plugin/filter/simplere.php
+++ b/plugin/filter/simplere.php
@@ -24,7 +24,7 @@ function filter_simplere($formatter,$value,$options) {
         $repl = array();
         foreach ($lines as $line) {
             $line=trim($line);
-            if ($line{0}=='#' or $line=='') continue;
+            if ($line[0]=='#' or $line=='') continue;
             if (preg_match('/^([\/@])([^\\1]+)\\1([^\\1]+)\\1$/',$line,$match)) {
                 $rule[] = $match[1].$match[2].$match[1];
                 $repl[] = $match[3];

--- a/plugin/msgtrans.php
+++ b/plugin/msgtrans.php
@@ -54,14 +54,14 @@ function macro_MsgTrans($formatter,$value,$param=array()) {
 
     foreach ($lines as $l) {
         $l=trim($l);
-        if ($l{0}=='#') {
+        if ($l[0]=='#') {
             if (preg_match('/^#lang(?'.'>uage)? (ko_KR|en_US|fr_FR)$/',$l,$m)) {
                 $lang=$m[1];
                 if ($DBInfo->charset) $lang.='.'.$charset;
             }
             continue;
         }
-        if ($l{0}=='"') {
+        if ($l[0]=='"') {
             if (preg_match('/^(("(([^"]|\\\\")*?)"\s*)+)\s*(.*)$/',$l,$m)) {
                 $smap = array('/"\s+"/', '/\\\\n/', '/\\\\r/', '/\\\\t/', '/\\\\"/');
                 $rmap = array('', "\n", "\r", "\t", '"');

--- a/plugin/processor/markdown.php
+++ b/plugin/processor/markdown.php
@@ -1230,9 +1230,9 @@ class Markdown_Parser {
 	# Handle $token provided by parseSpan by determining its nature and 
 	# returning the corresponding value that should replace it.
 	#
-		switch ($token{0}) {
+		switch ($token[0]) {
 			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
+				return $this->hashPart("&#". ord($token[1]). ";");
 			case "`":
 				# Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.$token.'(?!`)(.*)$/sm', 
@@ -1387,7 +1387,7 @@ class Processor_Markdown extends Markdown_Parser {
 	#
 	# strip bang-path #!markdown
 	#
-        	if ($text{0}=='#' and $text{1}=='!') {
+        	if ($text[0]=='#' and $text[1]=='!') {
             		list($line,$text)=explode("\n",$text,2);
             		$dum = preg_split('/\s+/', $line);
             		$myarg = $dum[1];
@@ -1570,7 +1570,7 @@ class Processor_Markdown extends Markdown_Parser {
 			{
 				# Tag is in code block or span and may not be a tag at all. So we
 				# simply skip the first char (should be a `<`).
-				$parsed .= $tag{0};
+				$parsed .= $tag[0];
 				$text = substr($tag, 1) . $text; # Put back $tag minus first char.
 			}
 			#
@@ -1596,7 +1596,7 @@ class Processor_Markdown extends Markdown_Parser {
 			#            HTML Comments, processing instructions.
 			#
 			else if (preg_match("{^<(?:$this->clean_tags)\b}", $tag) ||
-				$tag{1} == '!' || $tag{1} == '?')
+				$tag[1] == '!' || $tag[1] == '?')
 			{
 				# Need to parse tag and following text using the HTML parser.
 				# (don't check for markdown attribute)
@@ -1615,8 +1615,8 @@ class Processor_Markdown extends Markdown_Parser {
 				#
 				# Increase/decrease nested tag count.
 				#
-				if ($tag{1} == '/')						$depth--;
-				else if ($tag{strlen($tag)-2} != '/')	$depth++;
+				if ($tag[1] == '/')						$depth--;
+				else if ($tag[strlen($tag)-2] != '/')	$depth++;
 
 				if ($depth < 0) {
 					#
@@ -1717,7 +1717,7 @@ class Processor_Markdown extends Markdown_Parser {
 				# first character as filtered to prevent an infinite loop in the 
 				# parent function.
 				#
-				return array($original_text{0}, substr($original_text, 1));
+				return array($original_text[0], substr($original_text, 1));
 			}
 			
 			$block_text .= $parts[0]; # Text before current tag.
@@ -1729,7 +1729,7 @@ class Processor_Markdown extends Markdown_Parser {
 			#			 Comments and Processing Instructions.
 			#
 			if (preg_match("{^</?(?:$this->auto_close_tags)\b}", $tag) ||
-				$tag{1} == '!' || $tag{1} == '?')
+				$tag[1] == '!' || $tag[1] == '?')
 			{
 				# Just add the tag to the block as if it was text.
 				$block_text .= $tag;
@@ -1740,8 +1740,8 @@ class Processor_Markdown extends Markdown_Parser {
 				# the tag's name match base tag's.
 				#
 				if (preg_match("{^</?$base_tag_name\b}", $tag)) {
-					if ($tag{1} == '/')						$depth--;
-					else if ($tag{strlen($tag)-2} != '/')	$depth++;
+					if ($tag[1] == '/')						$depth--;
+					else if ($tag[strlen($tag)-2] != '/')	$depth++;
 				}
 				
 				#

--- a/plugin/processor/monimarkup.php
+++ b/plugin/processor/monimarkup.php
@@ -61,7 +61,7 @@ class processor_monimarkup
                             list($type,$dum)= explode("\n",$block[$j],2);
                             $tag='';
                             if (!empty($type)) {
-                                if ($type[0]=='#' and $type{1}=='!') {
+                                if ($type[0]=='#' and $type[1]=='!') {
                                     #list($tag,$dummy)= explode(' ',$type);
                                     $tmp = explode(' ',$type);
                                     $tag = $tmp[0];
@@ -72,7 +72,7 @@ class processor_monimarkup
                                     # for a quote block
                                     $block[$j]=substr($block[$j],1);
                                     $arg= substr($type,1);
-                                    if ($type{1}=='#' or $type{1}=='.') {
+                                    if ($type[1]=='#' or $type[1]=='.') {
                                         $btype[$j]='monimarkup';
                                         $block[$j]='#!monimarkup '.$arg."\n".$dum;
                                     } else {
@@ -349,7 +349,7 @@ class processor_monimarkup
                 continue;
             }
             $tr_diff='';
-            if ($line[0]== "\010" or $line{1}=="\006") {
+            if ($line[0]== "\010" or $line[1]=="\006") {
                 $tr_diff=$line[0] == "\010" ? 'diff-added':'diff-removed';
                 $line=substr($line,1,-1);
             }

--- a/plugin/ticket.php
+++ b/plugin/ticket.php
@@ -281,7 +281,7 @@ function do_ticket($formatter,$options) {
             }
             $FONT=$DBInfo->ticket_font;
             //$FONT="/home/foobar/data/PenguinAttack.ttf";
-            if ($FONT{0}=='/' and !file_exists($FONT)) {
+            if ($FONT[0]=='/' and !file_exists($FONT)) {
                 $use_ttf=0;
             } else {
                 $FONT=$DBInfo->ticket_font;

--- a/wiki.php
+++ b/wiki.php
@@ -1500,12 +1500,12 @@ class WikiPage {
       if (isset($Config['pagetype'][$key]) and $f=$Config['pagetype'][$key]) {
         $p=preg_split('%(:|/)%',$f);
         $p2=strlen($p[0].$p[1])+1;
-        $p[1]=isset($p[1]) ? $f{strlen($p[0])}.$p[1]:'';
-        $p[2]=isset($p[2]) ? $f{$p2}.$p[2]:'';
+        $p[1]=isset($p[1]) ? $f[strlen($p[0])].$p[1]:'';
+        $p[2]=isset($p[2]) ? $f[$p2].$p[2]:'';
         $format=$p[0];
         if (!empty($sep[1])) { # have : or /
-          $format = ($sep[1]==$p[1]{0}) ? substr($p[1],1):
-                    (($sep[1]==$p[2]{0}) ? substr($p[2],1):'plain');
+          $format = ($sep[1]==$p[1][0]) ? substr($p[1],1):
+                    (($sep[1]==$p[2][0]) ? substr($p[2],1):'plain');
         }
       } else if (isset($Config['pagetype']['*']))
         $format=$Config['pagetype']['*']; // default page type
@@ -2159,7 +2159,7 @@ EOJS;
   }
 
   function _diff_repl($arr) {
-    if ($arr[1]{0}=="\010") { $tag='ins'; $sty='added'; }
+    if ($arr[1][0]=="\010") { $tag='ins'; $sty='added'; }
     else { $tag='del'; $sty='removed'; }
     if (strpos($arr[2],"\n") !== false)
       return "<div class='diff-$sty'>".$arr[2]."</div>";
@@ -2183,7 +2183,7 @@ EOJS;
     $url=str_replace('\"','"',$url); // XXX
     $bra = '';
     $ket = '';
-    if ($url{0}=='[') {
+    if ($url[0]=='[') {
       $bra='[';
       $ket=']';
       $url=substr($url,1,-1);
@@ -2306,7 +2306,7 @@ EOJS;
       return $this->word_repl($bra.$url.$ket, '', $attr);
     } else
     if (($p = strpos($urltest, ':')) !== false and
-        (!isset($url{$p+1}) or (isset($url{$p+1}) and $url{$p+1}!=':'))) {
+        (!isset($url[$p+1]) or (isset($url[$p+1]) and $url[$p+1]!=':'))) {
 
       // namespaced pages
       // [[한글:페이지]], [[한글:페이지 이름]]
@@ -2533,7 +2533,7 @@ EOJS;
 
       return "<a class='externalLink' $attr href='$link' $this->external_target>$url</a>";
     } else {
-      if ($url{0}=='?')
+      if ($url[0]=='?')
         $url=substr($url,1);
 
       $url = preg_replace('/&amp;/i', '&', $url);
@@ -3034,7 +3034,7 @@ EOJS;
         if (!empty($options['nowrap']) and !empty($this->pi['#format']) and $processor == $this->pi['#format']) { $btag='';$etag=''; }
         else { $btag='{{{';$etag='}}}'; }
         $notag = '';
-        if ($value{0}!='#' and $value{1}!='!') $notag="\n";
+        if ($value[0]!='#' and $value[1]!='!') $notag="\n";
         $markups=str_replace(array('=','-','&','<'),array('==','-=','&amp;','&lt;'),$value);
         $bra= "<span class='wikiMarkup'><!-- wiki:\n".$btag.$notag.$markups.$etag."\n-->";
       }
@@ -3228,8 +3228,8 @@ EOJS;
         );
         $start=substr($numtype,1);
         $litype='';
-        if (array_key_exists($numtype{0},$lists))
-          $litype=' style="list-style-type:'.$lists[$numtype{0}].'"';
+        if (array_key_exists($numtype[0],$lists))
+          $litype=' style="list-style-type:'.$lists[$numtype[0]].'"';
         if (!empty($start)) {
           #$litype[]='list-type-style:'.$lists[$numtype{0}];
           return "<$list_type$litype start='$start'>";
@@ -4468,7 +4468,7 @@ EOJS;
       foreach ($js as $j) $this->register_javascripts($j);
       return true;
     } else {
-      if ($js{0} == '<') { $tag=md5($js); }
+      if ($js[0] == '<') { $tag=md5($js); }
       else $tag=$js;
       if (!isset($this->java_scripts[$tag]))
         $this->java_scripts[$tag]=$js;
@@ -4507,7 +4507,7 @@ EOJS;
 
       foreach ($this->java_scripts as $k=>$js) {
         if ($js) {
-          if ($js{0} != '<') {
+          if ($js[0] != '<') {
             $asyncOrDefer = '';
             if (strpos($js, ',') !== false) {
               $check = substr($js, 0, 5);
@@ -4570,7 +4570,7 @@ EOJS;
     $out='';
     foreach ($this->java_scripts as $k=>$js) {
       if ($js) {
-        if ($js{0} != '<') {
+        if ($js[0] != '<') {
           $asyncOrDefer = '';
           if (strpos($js, ',') !== false) {
             $check = substr($js, 0, 5);

--- a/wikilib.php
+++ b/wikilib.php
@@ -478,6 +478,7 @@ function _autofixencode($str) {
 
 if (!function_exists('_stripslashes')) {
 function _stripslashes($str) {
+  if (PHP_VERSION_ID >= 50400) return $str;
   return get_magic_quotes_gpc() ? stripslashes($str):$str;
 }
 }
@@ -1307,7 +1308,7 @@ function email_guard($email,$mode='hex') {
       $encode = '';
       $sz=strlen($email);
       for ($i=0; $i<$sz; $i++)
-        $encode .= '&#x' . bin2hex($email{$i}).';';
+        $encode .= '&#x' . bin2hex($email[$i]).';';
       return $encode;
 
     case 'none' :


### PR DESCRIPTION
 * use string offset access syntax to fix warnings : "Array and string offset access syntax with curly braces is deprecated"
 * fix deprecated `get_magic_quites_gpc()`