### PR TITLE
fix: resolved an issue with curly braces being deprecated

### DIFF
--- a/plugin/download.php
+++ b/plugin/download.php
@@ -15,7 +15,7 @@ function do_download($formatter,$options) {
     return; 
   }
   $value=&$options['value'];
-  $down_mode=(!empty($options['mode']) and $options['mode']{0}=='a') ? 'attachment':
+  $down_mode=(!empty($options['mode']) and $options['mode'][0]=='a') ? 'attachment':
     (!empty($DBInfo->download_mode) ? $DBInfo->download_mode:'inline');
 
   // SubPage:foobar.png == SubPage/foobar.png


### PR DESCRIPTION
This commit is to fix the issue to handle string offset access syntax with curly braces 
is deprecated. In case of the latest PHP version (e.g., 8.1.x), The array and string offset 
access syntax with curly braces is no longer supported in the ./plugin/download.php (line 18) file.

- Fixed issue #162

Signed-off-by: Geunsik Lim <leemgs@gmail.com>